### PR TITLE
[0.6.0] Minor cleanup + new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 A simple way to go about generating inventories for MythicMobs.
 
 > [!IMPORTANT]
-> The one and only dependency is MythicMobs, however the plugin can be used without it (the skills will just not work).
+> The one and only dependency is [MythicMobs](https://mythiccraft.io/index.php?resources/mythicmobs.1/), however the plugin can be used without it, the mm_skill option will just not work.
 
 ## Download
 You can download the latest version of MythicInventories [here](https://ci.heypr.dev/job/MythicInventories/).
 
 ## Support
-If you're having difficulty figuring out how to work with the plugin, [join my support Discord](https://discord.gg/Drgk3CxrtV/)!
+If you're having difficulty figuring out how to work with the plugin, need to report a bug, or are interested in 
+contributing to the project, please [join my support Discord](https://discord.gg/Drgk3CxrtV/)!
 
 ## Usage
 Making inventories is pretty simple. All you need to do is open up the MythicInventories folder, create a .yml file with a name of your choice, then create one! 
@@ -32,39 +33,73 @@ my_first_inventory:
       - "<blue>Woo: <gradient>||||||||||||||||||||||||</gradient>!"
       mm_skill: lightning_skill
       click_type: shift_left_click
+      save: false
+      interactable: false
 ```
 
 ## Options
 
-The "gui" option is for setting whether all items in the inventory are able to be picked up and manipulated. It is `true` (all items are *not* interactable) by default.
+- The `name` option is for setting the name of the inventory or the item. It is not required on either. If not set 
+  on the inventory, the name will default to "Container" & if not set on the item, it will default to the item's
+  material type.
 
-The "fill_item" option is for items that need to fill the inventory. It is `false` by default.
 
-The "interactable" option is for setting whether the item is able to be picked up and manipulated. It is `false` by default.
+- The `size` option is for setting the size of the inventory. It is optional, and should be a multiple of 9 and 
+  greater than 0. If it is not specified, it will be set to 9 by default.
 
-The "click_type" option is for setting the click type for the item. It is not set by default.
+
+- The `items` option is for setting the items in the inventory. Ideally you should add items to your inventory.
+
+
+- The `type` option is for setting the material type of the item. It is required.
+
+
+- The `slot` option is for setting the slot of the item. It is required.
+
+
+- The `lore` option is for setting the lore of the item. It is optional.
+
+
+- The `gui` option is for setting whether all items in the inventory can be picked up and manipulated. It is `true` by 
+default. Do note, that enabling this option will *not* allow players to modify anything in the inventory unless 
+explicitly set through the `interactable` option (see below).
+
+
+- The `fill_item` option is for items that need to fill the inventory. It is `false` by default, and is optional. 
+  Please note that only one item can be a fill item.
+
+
+- The `interactable` option is for setting whether the item can be picked up and manipulated. It is `false` by 
+default, and is optional.
+
+
+- The `save` option is for setting whether the item should be saved. It is `false` by default, and is optional.
+
+
+- The `click_type` option is for setting the click type for the item. It is not set by default, and is optional.
 Make sure to set this value to a valid click type if you want a skill to be executed when the item is clicked.
 Valid click types are as follows: 
-- LEFT_CLICK
-- RIGHT_CLICK
-- SHIFT_LEFT_CLICK
-- SHIFT_RIGHT_CLICK
-- MIDDLE_CLICK
-- SHIFT_MIDDLE_CLICK
-- DROP
-- HOTBAR_SWAP
+  - `LEFT_CLICK`
+  - `RIGHT_CLICK`
+  - `SHIFT_LEFT_CLICK`
+  - `SHIFT_RIGHT_CLICK`
+  - `MIDDLE_CLICK`
+  - `SHIFT_MIDDLE_CLICK`
+  - `DROP`
+  - `HOTBAR_SWAP`
 
-The "item_flags" option is for setting flags on the item. It is empty by default.
+
+- The `item_flags` option is for setting flags on the item. It is empty by default, and is optional.
 Valid values for item flags are as follows:
-- HIDE_ENCHANTS,
-- HIDE_ATTRIBUTES,
-- HIDE_UNBREAKABLE,
-- HIDE_DESTROYS,
-- HIDE_PLACED_ON,
-- HIDE_ADDITIONAL_TOOLTIP,
-- HIDE_DYE,
-- HIDE_ARMOR_TRIM,
-- HIDE_STORED_ENCHANTS;
+  - `HIDE_ENCHANTS`,
+  - `HIDE_ATTRIBUTES`,
+  - `HIDE_UNBREAKABLE`,
+  - `HIDE_DESTROYS`,
+  - `HIDE_PLACED_ON`,
+  - `HIDE_ADDITIONAL_TOOLTIP`,
+  - `HIDE_DYE`,
+  - `HIDE_ARMOR_TRIM`,
+  - `HIDE_STORED_ENCHANTS`;
 
 ## Commands
 | Command                              | Description                                                                                               | Permission                             | Aliases                                  |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A simple way to go about generating inventories for MythicMobs.
 
 > [!IMPORTANT]
-> The one and only dependency is MythicMobs. 
+> The one and only dependency is MythicMobs, however the plugin can be used without it (the skills will just not work).
 
 ## Download
 You can download the latest version of MythicInventories [here](https://ci.heypr.dev/job/MythicInventories/).

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'me.hyper'
-version = '0.5.5-b' + buildNumber() + '-DEV'
+version = '0.6.0-b' + buildNumber() + '-DEV'
 
 def buildNumber() {
     System.getenv("BUILD_NUMBER") ?: "UNKNOWN"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'me.hyper'
-version = '0.5.3-b' + buildNumber() + '-DEV'
+version = '0.5.4-b' + buildNumber() + '-DEV'
 
 def buildNumber() {
     System.getenv("BUILD_NUMBER") ?: "UNKNOWN"

--- a/src/main/java/dev/heypr/mythicinventories/MythicInventories.java
+++ b/src/main/java/dev/heypr/mythicinventories/MythicInventories.java
@@ -2,15 +2,13 @@ package dev.heypr.mythicinventories;
 
 import dev.heypr.mythicinventories.bstats.Metrics;
 import dev.heypr.mythicinventories.commands.OpenInventoryTabCompleter;
-import dev.heypr.mythicinventories.events.InventoryEvents;
+import dev.heypr.mythicinventories.events.BukkitInventoryEvents;
+import dev.heypr.mythicinventories.events.MythicMobEvents;
 import dev.heypr.mythicinventories.inventories.InventoryCreator;
 import dev.heypr.mythicinventories.inventories.MythicInventory;
 import dev.heypr.mythicinventories.commands.OpenInventoryCommand;
-import dev.heypr.mythicinventories.mythicmobs.OpenInventoryMechanic;
 import dev.heypr.mythicinventories.storage.MythicInventorySerializer;
-import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 import org.bukkit.Bukkit;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -35,20 +33,21 @@ public final class MythicInventories extends JavaPlugin implements Listener {
             return true;
         });
 
-        Bukkit.getPluginManager().registerEvents(new InventoryEvents(this), this);
+        Bukkit.getPluginManager().registerEvents(new BukkitInventoryEvents(this), this);
+
+        if (!isMythicMobsEnabled()) {
+            getLogger().warning("MythicMobs was not found! MythicInventories will have reduced functionality.");
+        }
+        else {
+            Bukkit.getPluginManager().registerEvents(new MythicMobEvents(this), this);
+        }
 
         createInventoriesDirectory();
         reloadInventories();
+
         new Metrics(this, 23863);
 
         getLogger().info("MythicInventories enabled!");
-    }
-
-    @EventHandler
-    public void onMythicMechanicLoad(MythicMechanicLoadEvent event)	{
-        if (event.getMechanicName().equalsIgnoreCase("openinventory")) {
-            event.register(new OpenInventoryMechanic(event.getConfig(), this));
-        }
     }
 
     @Override
@@ -106,5 +105,13 @@ public final class MythicInventories extends JavaPlugin implements Listener {
      */
     public void addInventory(MythicInventory inventory, String inventoryId) {
         inventories.put(inventoryId, inventory);
+    }
+
+    public boolean isMythicMobsEnabled() {
+        return getServer().getPluginManager().isPluginEnabled("MythicMobs");
+    }
+
+    public io.lumine.mythic.bukkit.MythicBukkit getMythicInst() {
+        return io.lumine.mythic.bukkit.MythicBukkit.inst();
     }
 }

--- a/src/main/java/dev/heypr/mythicinventories/MythicInventories.java
+++ b/src/main/java/dev/heypr/mythicinventories/MythicInventories.java
@@ -6,8 +6,12 @@ import dev.heypr.mythicinventories.events.InventoryEvents;
 import dev.heypr.mythicinventories.inventories.InventoryCreator;
 import dev.heypr.mythicinventories.inventories.MythicInventory;
 import dev.heypr.mythicinventories.commands.OpenInventoryCommand;
+import dev.heypr.mythicinventories.mythicmobs.OpenInventoryMechanic;
 import dev.heypr.mythicinventories.storage.MythicInventorySerializer;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
 import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -15,7 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class MythicInventories extends JavaPlugin {
+public final class MythicInventories extends JavaPlugin implements Listener {
 
     // Format: internal inventory name -> MythicInventory object
     private final Map<String, MythicInventory> inventories = new HashMap<>();
@@ -40,21 +44,38 @@ public final class MythicInventories extends JavaPlugin {
         getLogger().info("MythicInventories enabled!");
     }
 
+    @EventHandler
+    public void onMythicMechanicLoad(MythicMechanicLoadEvent event)	{
+        if (event.getMechanicName().equalsIgnoreCase("openinventory")) {
+            event.register(new OpenInventoryMechanic(event.getConfig(), this));
+        }
+    }
+
     @Override
     public void onDisable() {
         inventories.clear();
         getLogger().info("MythicInventories disabled!");
     }
 
+    /**
+     * Get the inventory serializer.
+     * @return The inventory serializer.
+     */
     public MythicInventorySerializer getInventorySerializer() {
         return new MythicInventorySerializer(this);
     }
 
+    /**
+     * Reload all inventories.
+     */
     public void reloadInventories() {
         inventories.clear();
         new InventoryCreator(this).loadInventories();
     }
 
+    /**
+     * Creates the "inventories" directory if it doesn't exist.
+     */
     private void createInventoriesDirectory() {
         File inventoriesDir = new File(getDataFolder(), "inventories");
         if (!inventoriesDir.exists()) {
@@ -62,14 +83,27 @@ public final class MythicInventories extends JavaPlugin {
         }
     }
 
+    /**
+     * Get a map of all inventories.
+     * @return A map of all inventories.
+     */
     public Map<String, MythicInventory> getInventories() {
         return inventories;
     }
 
+    /**
+     * Get a list of all inventory names.
+     * @return A list of all inventory names.
+     */
     public List<String> getInventoryNames() {
         return inventories.keySet().stream().toList();
     }
 
+    /**
+     * Add an inventory to the list.
+     * @param inventory The inventory to add.
+     * @param inventoryId The internal name of the inventory.
+     */
     public void addInventory(MythicInventory inventory, String inventoryId) {
         inventories.put(inventoryId, inventory);
     }

--- a/src/main/java/dev/heypr/mythicinventories/MythicInventories.java
+++ b/src/main/java/dev/heypr/mythicinventories/MythicInventories.java
@@ -6,6 +6,7 @@ import dev.heypr.mythicinventories.events.InventoryEvents;
 import dev.heypr.mythicinventories.inventories.InventoryCreator;
 import dev.heypr.mythicinventories.inventories.MythicInventory;
 import dev.heypr.mythicinventories.commands.OpenInventoryCommand;
+import dev.heypr.mythicinventories.storage.MythicInventorySerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -43,6 +44,10 @@ public final class MythicInventories extends JavaPlugin {
     public void onDisable() {
         inventories.clear();
         getLogger().info("MythicInventories disabled!");
+    }
+
+    public MythicInventorySerializer getInventorySerializer() {
+        return new MythicInventorySerializer(this);
     }
 
     public void reloadInventories() {

--- a/src/main/java/dev/heypr/mythicinventories/commands/OpenInventoryCommand.java
+++ b/src/main/java/dev/heypr/mythicinventories/commands/OpenInventoryCommand.java
@@ -47,6 +47,10 @@ public class OpenInventoryCommand implements CommandExecutor {
             return true;
         }
 
+        if (plugin.getInventorySerializer().getPlayerInventoryNames(target).contains(inventoryName)) {
+            target.openInventory(plugin.getInventorySerializer().loadInventory(mythicInventory, target).getInventory());
+            return true;
+        }
         target.openInventory(mythicInventory.getInventory());
         return true;
     }

--- a/src/main/java/dev/heypr/mythicinventories/events/BukkitInventoryEvents.java
+++ b/src/main/java/dev/heypr/mythicinventories/events/BukkitInventoryEvents.java
@@ -1,6 +1,5 @@
 package dev.heypr.mythicinventories.events;
 
-import io.lumine.mythic.bukkit.MythicBukkit;
 import dev.heypr.mythicinventories.MythicInventories;
 import dev.heypr.mythicinventories.inventories.MythicInventory;
 import org.bukkit.NamespacedKey;
@@ -13,11 +12,11 @@ import org.bukkit.persistence.PersistentDataType;
 
 import static org.bukkit.event.inventory.InventoryAction.*;
 
-public class InventoryEvents implements Listener {
+public class BukkitInventoryEvents implements Listener {
 
     private final MythicInventories plugin;
 
-    public InventoryEvents(MythicInventories plugin) {
+    public BukkitInventoryEvents(MythicInventories plugin) {
         this.plugin = plugin;
     }
 
@@ -62,7 +61,12 @@ public class InventoryEvents implements Listener {
         if (skillName == null) {
             return;
         }
-        MythicBukkit.inst().getAPIHelper().castSkill(event.getWhoClicked(), skillName);
+        if (plugin.isMythicMobsEnabled()) {
+            plugin.getMythicInst().getAPIHelper().castSkill(event.getWhoClicked(), skillName);
+        }
+        else {
+            plugin.getLogger().warning("MythicMobs is not enabled! Cannot cast skill: " + skillName);
+        }
     }
 
     private void castSkill(InventoryClickEvent event, ItemStack item) {
@@ -74,7 +78,12 @@ public class InventoryEvents implements Listener {
         if (skillName == null) {
             return;
         }
-        MythicBukkit.inst().getAPIHelper().castSkill(event.getWhoClicked(), skillName);
+        if (plugin.isMythicMobsEnabled()) {
+            plugin.getMythicInst().getAPIHelper().castSkill(event.getWhoClicked(), skillName);
+        }
+        else {
+            plugin.getLogger().warning("MythicMobs is not enabled! Cannot cast skill: " + skillName);
+        }
     }
 
     private void checkClickType(InventoryClickEvent event, ItemStack item) {
@@ -161,6 +170,14 @@ public class InventoryEvents implements Listener {
         }
     }
 
+    private boolean isInteractable(MythicInventory inventory, int slot) {
+        return inventory.getInteractableItems().containsKey(slot);
+    }
+
+    private boolean hasInteractable(MythicInventory inventory) {
+        return !inventory.getInteractableItems().isEmpty();
+    }
+
 // TODO: fix this shit
 //    private void runCommands(ItemStack item) {
 //        NamespacedKey key = new NamespacedKey(plugin, "commands");
@@ -184,12 +201,4 @@ public class InventoryEvents implements Listener {
 //            }
 //        }
 //    }
-
-    private boolean isInteractable(MythicInventory inventory, int slot) {
-        return inventory.getInteractableItems().containsKey(slot);
-    }
-
-    private boolean hasInteractable(MythicInventory inventory) {
-        return !inventory.getInteractableItems().isEmpty();
-    }
 }

--- a/src/main/java/dev/heypr/mythicinventories/events/MythicMobEvents.java
+++ b/src/main/java/dev/heypr/mythicinventories/events/MythicMobEvents.java
@@ -1,0 +1,23 @@
+package dev.heypr.mythicinventories.events;
+
+import dev.heypr.mythicinventories.MythicInventories;
+import dev.heypr.mythicinventories.mythicmobs.OpenInventoryMechanic;
+import io.lumine.mythic.bukkit.events.MythicMechanicLoadEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class MythicMobEvents implements Listener {
+
+    private final MythicInventories plugin;
+
+    public MythicMobEvents(MythicInventories plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onMythicMechanicLoad(MythicMechanicLoadEvent event)	{
+        if (event.getMechanicName().equalsIgnoreCase("openinventory")) {
+            event.register(new OpenInventoryMechanic(event.getConfig(), plugin));
+        }
+    }
+}

--- a/src/main/java/dev/heypr/mythicinventories/inventories/InventoryCreator.java
+++ b/src/main/java/dev/heypr/mythicinventories/inventories/InventoryCreator.java
@@ -2,7 +2,6 @@ package dev.heypr.mythicinventories.inventories;
 
 import dev.heypr.mythicinventories.MythicInventories;
 import dev.heypr.mythicinventories.misc.ClickTypes;
-import io.lumine.mythic.bukkit.MythicBukkit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -286,7 +285,11 @@ public class InventoryCreator {
      */
     private void hasMMSkill(Map<?, ?> itemData, ItemMeta meta) {
         String skillName = itemData.get("mm_skill").toString();
-        if (MythicBukkit.inst().getSkillManager().getSkill(skillName).isEmpty()) {
+        if (!plugin.isMythicMobsEnabled()) {
+            plugin.getLogger().warning("MythicMobs is not enabled! Cannot set skill: " + skillName);
+            return;
+        }
+        if (plugin.getMythicInst().getSkillManager().getSkill(skillName).isEmpty()) {
             plugin.getLogger().severe("Invalid skill name \"" + skillName + "\" in inventory \"" + inventoryId + "\"!");
             return;
         }

--- a/src/main/java/dev/heypr/mythicinventories/inventories/InventoryCreator.java
+++ b/src/main/java/dev/heypr/mythicinventories/inventories/InventoryCreator.java
@@ -61,7 +61,7 @@ public class InventoryCreator {
                         continue;
                     }
 
-                    String displayName = inventorySection.getString("name", inventoryId);
+                    String displayName = inventorySection.getString("name", "Container");
                     int size = inventorySection.getInt("size", 9);
 
                     if (size % 9 != 0) {

--- a/src/main/java/dev/heypr/mythicinventories/inventories/InventoryCreator.java
+++ b/src/main/java/dev/heypr/mythicinventories/inventories/InventoryCreator.java
@@ -29,6 +29,7 @@ public class InventoryCreator {
 
     private final MythicInventories plugin;
     private String inventoryId;
+    private Map<?, ?> itemData;
 
     public InventoryCreator(MythicInventories plugin) {
         this.plugin = plugin;
@@ -70,6 +71,7 @@ public class InventoryCreator {
                     }
 
                     MythicInventory inventory = new MythicInventory(plugin, size, deserializeText(displayName));
+                    inventory.setInternalName(inventoryId);
                     List<Map<?, ?>> items = inventorySection.getMapList("items");
 
                     boolean fillItemExists = false;
@@ -77,12 +79,13 @@ public class InventoryCreator {
                     for (Map<?, ?> itemData : items) {
 
                         this.inventoryId = inventoryId;
+                        this.itemData = itemData;
 
                         try {
                             int slot = 0;
                             boolean fillItem = false;
 
-                            if (itemData.containsKey("slot")) {
+                            if (checkValue("slot")) {
                                 int fl = getSlot(itemData);
                                 if (fl == 0) {
                                     continue;
@@ -90,11 +93,11 @@ public class InventoryCreator {
                                 slot = getSlot(itemData);
                             }
 
-                            if (itemData.containsKey("fill_item")) {
-                                if (!hasFillItem(itemData)) {
+                            if (checkValue("fill_item")) {
+                                if (!isFillItem(itemData)) {
                                     continue;
                                 }
-                                fillItem = hasFillItem(itemData);
+                                fillItem = isFillItem(itemData);
                             }
 
                             if (slot == 0 && !fillItem) {
@@ -109,7 +112,7 @@ public class InventoryCreator {
                                 plugin.getLogger().severe("Both \"slot\" and \"fill_item\" options found for item in inventory \"" + inventoryId + "\"! Please only define one.");
                                 continue;
                             }
-                            if (!itemData.containsKey("type")) {
+                            if (!checkValue("type")) {
                                 plugin.getLogger().severe("No item type found for item in inventory \"" + inventoryId + "\"!");
                                 continue;
                             }
@@ -127,52 +130,51 @@ public class InventoryCreator {
                             ItemStack item = new ItemStack(material);
                             ItemMeta meta = item.getItemMeta();
 
-                            if (itemData.containsKey("amount")) {
+                            if (checkValue("amount")) {
                                 int amount = getAmount(itemData);
                                 if (amount == 0) {
-                                    continue;
+                                    plugin.getLogger().severe("Setting amount to 1.");
+                                    amount = 1;
                                 }
                                 item.setAmount(amount);
                             }
+                            else {
+                                item.setAmount(1);
+                            }
 
-                            if (itemData.containsKey("name")) {
+                            if (checkValue("name")) {
                                 meta.displayName(deserializeText(itemData.get("name").toString()).asComponent().decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE));
                             }
 
-                            if (itemData.containsKey("lore")) {
+                            if (checkValue("lore")) {
                                 List<Component> lore = getLore(itemData);
-                                if (lore == null) {
-                                    continue;
-                                }
-                                meta.lore(lore);
-                            }
-
-                            if (itemData.containsKey("mm_skill")) {
-                                if (!handleMMSkill(itemData, meta)) {
-                                    continue;
+                                if (lore != null) {
+                                    meta.lore(lore);
                                 }
                             }
 
-                            if (itemData.containsKey("click_type")) {
-                                if (!handleClickType(itemData, meta)) {
-                                    continue;
-                                }
+                            if (checkValue("mm_skill")) {
+                                hasMMSkill(itemData, meta);
                             }
 
-                            if (itemData.containsKey("item_flags")) {
-                                if (!handleItemFlags(itemData, meta, item)) {
-                                    continue;
-                                }
+                            if (checkValue("click_type")) {
+                                hasClickType(itemData, meta);
                             }
 
-                            if (itemData.containsKey("interactable")) {
-                                if (!(handleIfInteractable(itemData, meta, item))) {
-                                    continue;
-                                }
+                            if (checkValue("item_flags")) {
+                                hasItemFlags(itemData, meta, item);
+                            }
+
+                            if (checkValue("interactable")) {
+                                isInteractable(itemData, slot, item, inventory);
+                            }
+
+                            if (checkValue("save")) {
+                                shouldSave(itemData, slot, inventory);
                             }
 
                             // TODO: Implement commands
-                            //if (itemData.containsKey("commands")) {
+                            //if (checkValue("commands")) {
                             //    List<?> commandsList = itemData.get("commands") instanceof List ? (List<?>) itemData.get("commands") : null;
                             //    if (commandsList == null) {
                             //        plugin.getLogger().severe("Invalid commands format/options in inventory \"" + inventoryId + "\" with item type " + material + "!");
@@ -230,7 +232,7 @@ public class InventoryCreator {
         return legacy.deserialize(legacy.serialize(mm.deserialize(text).asComponent()));
     }
 
-    private boolean hasFillItem(Map<?, ?> itemData) {
+    private boolean isFillItem(Map<?, ?> itemData) {
         Object fillItemObj = itemData.get("fill_item");
         if (fillItemObj instanceof Boolean) {
             return (boolean) fillItemObj;
@@ -241,6 +243,12 @@ public class InventoryCreator {
         }
     }
 
+    /**
+     * Get the amount of the item.
+     *
+     * @param itemData The item data.
+     * @return The amount of the item.
+     */
     private int getAmount(Map<?, ?> itemData) {
         Object amountObj = itemData.get("amount");
         if (amountObj instanceof Integer) {
@@ -252,6 +260,12 @@ public class InventoryCreator {
         }
     }
 
+    /**
+     * Get the lore for the item.
+     *
+     * @param itemData The item data.
+     * @return The lore for the item.
+     */
     private List<Component> getLore(Map<?, ?> itemData) {
         List<?> loreList = itemData.get("lore") instanceof List ? (List<?>) itemData.get("lore") : null;
         if (loreList == null) {
@@ -264,18 +278,30 @@ public class InventoryCreator {
                 .toList();
     }
 
-    private boolean handleMMSkill(Map<?, ?> itemData, ItemMeta meta) {
+    /**
+     * Checks if the item has a MythicMobs skill.
+     *
+     * @param itemData The item data.
+     * @param meta The item meta.
+     */
+    private void hasMMSkill(Map<?, ?> itemData, ItemMeta meta) {
         String skillName = itemData.get("mm_skill").toString();
         if (MythicBukkit.inst().getSkillManager().getSkill(skillName).isEmpty()) {
             plugin.getLogger().severe("Invalid skill name \"" + skillName + "\" in inventory \"" + inventoryId + "\"!");
-            return false;
+            return;
         }
         NamespacedKey key = new NamespacedKey(plugin, "skill");
         meta.getPersistentDataContainer().set(key, PersistentDataType.STRING, skillName);
-        return true;
     }
 
-    private boolean handleClickType(Map<?, ?> itemData, ItemMeta meta) {
+    /**
+     * Checks if the item has a click type.
+     *
+     * @param itemData The item data.
+     * @param meta The item meta.
+     * @return True if the item has a click type, false otherwise.
+     */
+    private boolean hasClickType(Map<?, ?> itemData, ItemMeta meta) {
         String clickType = itemData.get("click_type").toString().toUpperCase();
         if (Arrays.stream(ClickTypes.values()).noneMatch(type -> type.name().equals(clickType))) {
             plugin.getLogger().severe("Invalid click type \"" + clickType + "\" in inventory \"" + inventoryId + "\"!");
@@ -286,11 +312,18 @@ public class InventoryCreator {
         return true;
     }
 
-    private boolean handleItemFlags(Map<?, ?> itemData, ItemMeta meta, ItemStack item) {
+    /**
+     * Checks if the item has item flags.
+     *
+     * @param itemData The item data.
+     * @param meta The item meta.
+     * @param item The item to check.
+     */
+    private void hasItemFlags(Map<?, ?> itemData, ItemMeta meta, ItemStack item) {
         List<?> itemFlagList = itemData.get("item_flags") instanceof List ? (List<?>) itemData.get("item_flags") : null;
         if (itemFlagList == null) {
             plugin.getLogger().severe("Invalid item_flag format/options in inventory \"" + inventoryId + "\" with item type " + item.getType() + "!");
-            return false;
+            return;
         }
         for (Object flag : itemFlagList) {
             try {
@@ -298,23 +331,51 @@ public class InventoryCreator {
             }
             catch (IllegalArgumentException e) {
                 plugin.getLogger().severe("Invalid item flag \"" + flag + "\" in inventory \"" + inventoryId + "\"" + "!");
-                return false;
+                return;
             }
         }
-        return true;
     }
 
-    private boolean handleIfInteractable(Map<?, ?> itemData, ItemMeta meta, ItemStack item) {
+    /**
+     * Checks if the item is interactable.
+     *
+     * @param itemData The item data.
+     * @param slot     The slot of the item.
+     * @param item     The item to check.
+     * @param inventory The inventory to add the interactable item to.
+     */
+    private void isInteractable(Map<?, ?> itemData, int slot, ItemStack item, MythicInventory inventory) {
         Boolean interactable = (Boolean) itemData.get("interactable");
         if (interactable == null) {
             plugin.getLogger().severe("Invalid interactable value found in inventory \"" + inventoryId + "\" with item type " + item.getType() + "!");
-            return false;
+            return;
         }
-        NamespacedKey key = new NamespacedKey(plugin, "interactable");
-        meta.getPersistentDataContainer().set(key, PersistentDataType.BOOLEAN, interactable);
-        return true;
+        if (!interactable) return;
+        inventory.addInteractableItem(slot, item);
     }
 
+    /**
+     * Checks if the item should be saved.
+     *
+     * @param itemData The item data.
+     * @param inventory The inventory to save the item to.
+     */
+    private void shouldSave(Map<?, ?> itemData, int slot, MythicInventory inventory) {
+        Boolean save = (Boolean) itemData.get("save");
+        if (save == null) {
+            plugin.getLogger().severe("Invalid save value found in inventory \"" + inventoryId + "!");
+            return;
+        }
+        if (!save) return;
+        inventory.addSavedItem(slot);
+    }
+
+    /**
+     * Get the slot number for the item.
+     *
+     * @param itemData The item data.
+     * @return The slot number for the item, 0 if invalid or not found.
+     */
     private int getSlot(Map<?, ?> itemData) {
         Object slotObj = itemData.get("slot");
         if (slotObj instanceof Integer) {
@@ -324,5 +385,15 @@ public class InventoryCreator {
             plugin.getLogger().severe("Invalid slot value \"" + slotObj + "\" in inventory \"" + inventoryId + "\"!");
             return 0;
         }
+    }
+
+    /**
+     * Check if the item has the given value, basic thing to reduce the weird "containsKey" stuff.
+     *
+     * @param key The key to check (duh).
+     * @return True if the item has the value, false otherwise.
+     */
+    private boolean checkValue(String key) {
+        return itemData.containsKey(key);
     }
 }

--- a/src/main/java/dev/heypr/mythicinventories/inventories/MythicInventory.java
+++ b/src/main/java/dev/heypr/mythicinventories/inventories/MythicInventory.java
@@ -7,12 +7,31 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
 public class MythicInventory implements InventoryHolder {
 
     private final Inventory inventory;
+    private String internalName;
+    private final Set<Integer> savedItems = new HashSet<>();
+    private final HashMap<Integer, ItemStack> interactableItems = new HashMap<>();
+
 
     public MythicInventory(MythicInventories plugin, int size, Component title) {
         this.inventory = plugin.getServer().createInventory(this, size, title);
+    }
+
+    /**
+     * Constructor for getting an existing inventory.
+     * Do not use this constructor for creating a new inventory.
+     *
+     * @param plugin       Instance of the MythicInventories plugin.
+     * @param internalName The internal name of the inventory.
+     */
+    public MythicInventory(MythicInventories plugin, String internalName) {
+        this.inventory = plugin.getInventories().get(internalName).getInventory();
     }
 
     @NotNull
@@ -21,7 +40,99 @@ public class MythicInventory implements InventoryHolder {
         return this.inventory;
     }
 
+    /**
+     * Get the internal name of the inventory.
+     *
+     * @return The internal name of the inventory.
+     */
+    public String getInternalName() {
+        return internalName;
+    }
+
+    /**
+     * Set the internal name of the inventory.
+     *
+     * @param internalName The internal name of the inventory.
+     */
+    public void setInternalName(String internalName) {
+        this.internalName = internalName;
+    }
+
+    /**
+     * Get the item in the specified slot.
+     *
+     * @param slot The slot to get the item from.
+     * @param item The item in the specified slot.
+     */
     public void setItem(int slot, ItemStack item) {
-        this.inventory.setItem(slot - 1, item);
+        this.inventory.setItem(slot, item);
+    }
+
+    /**
+     * Gets all the unsaved items in the inventory.
+     * <p>
+     * Map contains the item as the key and the slot as the value.
+     *
+     * @return A map of all the unsaved items in the inventory.
+     */
+    public Set<Integer> getSavedItems() {
+        return savedItems;
+    }
+
+    /**
+     * Add an unsaved item to the inventory.
+     *
+     * @param slot The slot to add the item to.
+     */
+    public void addSavedItem(int slot) {
+        savedItems.add(slot);
+    }
+
+    /**
+     * Remove an unsaved item from the inventory.
+     *
+     * @param slot The slot to remove the item from.
+     */
+    public void removeSavedItem(int slot) {
+        savedItems.remove(slot);
+    }
+
+    /**
+     * Gets all the interactable items in the inventory.
+     * <p>
+     * Map contains the item as the key and the slot as the value.
+     *
+     * @return A map of all the interactable items in the inventory.
+     */
+    public HashMap<Integer, ItemStack> getInteractableItems() {
+        return interactableItems;
+    }
+
+    /**
+     * Add an interactable item to the inventory.
+     *
+     * @param item The item to add.
+     * @param slot The slot to add the item to.
+     */
+    public void addInteractableItem(int slot, ItemStack item) {
+        interactableItems.put(slot, item);
+    }
+
+    /**
+     * Remove an interactable item from the inventory.
+     *
+     * @param item The item to remove.
+     */
+    public void removeInteractableItem(ItemStack item) {
+        interactableItems.entrySet().removeIf(entry -> entry.getValue().equals(item));
+    }
+
+    /**
+     * Remove an interactable item from the inventory.
+     *
+     * @param slot The slot to remove the item from.
+     */
+    public void removeInteractableItem(int slot) {
+        interactableItems.remove(slot);
     }
 }

--- a/src/main/java/dev/heypr/mythicinventories/mythicmobs/OpenInventoryMechanic.java
+++ b/src/main/java/dev/heypr/mythicinventories/mythicmobs/OpenInventoryMechanic.java
@@ -1,0 +1,48 @@
+package dev.heypr.mythicinventories.mythicmobs;
+
+import dev.heypr.mythicinventories.MythicInventories;
+import dev.heypr.mythicinventories.inventories.MythicInventory;
+import io.lumine.mythic.api.adapters.AbstractEntity;
+import io.lumine.mythic.api.config.MythicLineConfig;
+import io.lumine.mythic.api.skills.ITargetedEntitySkill;
+import io.lumine.mythic.api.skills.SkillMetadata;
+import io.lumine.mythic.api.skills.SkillResult;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import org.bukkit.entity.Player;
+
+public class OpenInventoryMechanic implements ITargetedEntitySkill {
+
+    protected final String inventoryName;
+    private final MythicInventories plugin;
+
+    public OpenInventoryMechanic(MythicLineConfig config, MythicInventories plugin) {
+        this.plugin = plugin;
+        this.inventoryName = config.getString(new String[] {"inventory", "i", "invname"});
+    }
+
+    @Override
+    public SkillResult castAtEntity(SkillMetadata metadata, AbstractEntity entity) {
+        Player target = (Player) BukkitAdapter.adapt(entity);
+        if (inventoryName == null) {
+            return SkillResult.INVALID_CONFIG;
+        }
+
+        if (!plugin.getInventories().containsKey(inventoryName)) {
+            return SkillResult.ERROR;
+        }
+
+        if (!target.hasPermission("mythicinventories.open." + inventoryName)) {
+            return SkillResult.ERROR;
+        }
+
+        MythicInventory mythicInventory = plugin.getInventories().get(inventoryName);
+
+        if (plugin.getInventorySerializer().getPlayerInventoryNames(target).contains(inventoryName)) {
+            target.openInventory(plugin.getInventorySerializer().loadInventory(mythicInventory, target).getInventory());
+            return SkillResult.SUCCESS;
+        }
+        
+        target.openInventory(mythicInventory.getInventory());
+        return SkillResult.SUCCESS;
+    }
+}

--- a/src/main/java/dev/heypr/mythicinventories/storage/MythicInventorySerializer.java
+++ b/src/main/java/dev/heypr/mythicinventories/storage/MythicInventorySerializer.java
@@ -1,0 +1,170 @@
+package dev.heypr.mythicinventories.storage;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import dev.heypr.mythicinventories.MythicInventories;
+import dev.heypr.mythicinventories.inventories.MythicInventory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.*;
+import java.lang.reflect.Type;
+import java.util.*;
+
+public class MythicInventorySerializer {
+
+    private final MythicInventories plugin;
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    public MythicInventorySerializer(MythicInventories plugin) {
+        this.plugin = plugin;
+        createPlayerDataDirectory();
+    }
+
+    /**
+     * Create the "playerdata" directory if it doesn't exist.
+     */
+    private void createPlayerDataDirectory() {
+        File playerDataDir = new File(plugin.getDataFolder(), "playerdata");
+        if (!playerDataDir.exists() && !playerDataDir.mkdirs()) {
+            plugin.getLogger().severe("Failed to create playerdata directory!");
+        }
+    }
+
+    /**
+     * Serialize the inventory to JSON.
+     */
+    public String serializeToJson(MythicInventory inventory) {
+        List<Map<String, Object>> inventoryData = new ArrayList<>();
+        for (int i = 0; i < inventory.getInventory().getSize(); i++) {
+            ItemStack item = inventory.getInventory().getItem(i);
+            if (item == null) continue;
+            if (!inventory.getSavedItems().contains(i)) continue;
+            try {
+                Map<String, Object> itemData = new HashMap<>();
+                itemData.put("slot", i);
+                itemData.put("item", item.serialize());
+                inventoryData.add(itemData);
+            }
+            catch (Exception e) {
+                plugin.getLogger().severe("Failed to serialize item in slot " + i + ": " + e.getMessage());
+            }
+        }
+        return gson.toJson(inventoryData);
+    }
+
+
+    /**
+     * Deserialize an inventory from a JSON file.
+     * @param file The file to deserialize the inventory from.
+     * @param inventoryInternalName The name of the inventory.
+     */
+    public MythicInventory deserializeInventoryFromJson(File file, String inventoryInternalName) {
+        try (FileReader reader = new FileReader(file)) {
+            JsonArray jsonArray = gson.fromJson(reader, JsonArray.class);
+
+            MythicInventory inventory = new MythicInventory(plugin, inventoryInternalName);
+
+            for (JsonElement element : jsonArray) {
+                JsonObject obj = element.getAsJsonObject();
+                int slot = obj.get("slot").getAsInt();
+                JsonObject itemObj = obj.getAsJsonObject("item");
+
+                Map<String, Object> itemData = gson.fromJson(itemObj, Map.class);
+                ItemStack item = ItemStack.deserialize(itemData);
+
+                inventory.setItem(slot, item);
+            }
+
+            return inventory;
+        }
+        catch (IOException e) {
+            plugin.getLogger().severe("Failed to load inventory from file: " + file.getName());
+            return null;
+        }
+        catch (Exception e) {
+            plugin.getLogger().severe("An error occurred while deserializing inventory: " + e.getMessage());
+            return null;
+        }
+    }
+
+
+
+    /**
+     * Save inventory to a JSON file in the player's directory.
+     * @param inventory The inventory to save.
+     * @param player The player to save the inventory for.
+     */
+    public void saveInventory(MythicInventory inventory, Player player) {
+        File playerDir = new File(plugin.getDataFolder(), "playerdata/" + player.getUniqueId());
+        if (!playerDir.exists() && !playerDir.mkdirs()) {
+            plugin.getLogger().severe("Failed to create directory for player: " + player.getUniqueId());
+            return;
+        }
+
+        File file = new File(playerDir, inventory.getInternalName() + ".json");
+        String jsonString = serializeToJson(inventory);
+        saveToJsonFile(jsonString, file);
+    }
+
+    /**
+     * Save inventory to a JSON file in the inventories directory for when a player is not specified.
+     * Remember that the internal name of the inventory is used as the file name.
+     * @param inventory The inventory to save.
+     */
+    public void saveInventory(MythicInventory inventory) {
+        File file = new File(plugin.getDataFolder(), "inventorydata/" + inventory.getInternalName() + ".json");
+        String jsonString = serializeToJson(inventory);
+        saveToJsonFile(jsonString, file);
+    }
+
+    /**
+     * Load an inventory from a player's directory.
+     * @param inventory The inventory to load.
+     * @param player The player to load the inventory for.
+     */
+    public MythicInventory loadInventory(MythicInventory inventory, Player player) {
+        File file = new File(plugin.getDataFolder(), "playerdata/" + player.getUniqueId() + "/" + inventory.getInternalName() + ".json");
+        if (!file.exists()) {
+            plugin.getLogger().warning("Inventory file not found: " + file.getName());
+            return null;
+        }
+        return deserializeInventoryFromJson(file, inventory.getInternalName());
+    }
+
+    /**
+     * Save serialized inventory to a file.
+     * @param jsonString The serialized inventory.
+     * @param file The file to save the inventory to.
+     */
+    private void saveToJsonFile(String jsonString, File file) {
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(jsonString);
+        }
+        catch (IOException e) {
+            plugin.getLogger().severe("Failed to save inventory to file: " + file.getName());
+        }
+    }
+
+    /**
+     * Get a list of saved inventory names from a player.
+     * @param player The player to get the inventory names from.
+     */
+    public List<String> getPlayerInventoryNames(Player player) {
+        File playerDir = new File(plugin.getDataFolder(), "playerdata/" + player.getUniqueId());
+        if (!playerDir.exists()) {
+            return Collections.emptyList();
+        }
+
+        File[] files = playerDir.listFiles((dir, name) -> name.endsWith(".json"));
+        if (files == null || files.length == 0) {
+            return Collections.emptyList();
+        }
+
+        List<String> inventoryNames = new ArrayList<>();
+        for (File file : files) {
+            inventoryNames.add(file.getName().replace(".json", ""));
+        }
+        return inventoryNames;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: '${version}'
 main: dev.heypr.mythicinventories.MythicInventories
 author: heypr
 api-version: '1.20'
-depend:
+softdepend:
   - MythicMobs
 commands:
   mythicinventoryopen:


### PR DESCRIPTION
- New per-player inventory saving feature, items in inventories with the option will save that slot to the player internally!
- New MythicMobs mechanic `openinventory` - lets you open the specified inventory for the specified player. 
- New `save` option for slots/items - lets you save the specified slot on the player who opened the inventory.
- New `interactable` option for slots/items - lets you change whether a slot can be modified (dragged/changed).
- Very small internal cleanup, still much more to be done. 
- Added some additional methods to the MythicInventory class.

Resolves #2 